### PR TITLE
Updated SDK and Examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 obj
 x32
 x64
+.vs
 *.opensdf
 *.sdf
 *.user

--- a/API/RainmeterAPI.cs
+++ b/API/RainmeterAPI.cs
@@ -22,6 +22,11 @@ namespace Rainmeter
             m_Rm = rm;
         }
 
+        static public implicit operator API(IntPtr rm)
+        {
+            return new Rainmeter.API(rm);
+        }
+
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode)]
         private extern static IntPtr RmReadString(IntPtr rm, string option, string defValue, bool replaceMeasures);
 
@@ -34,6 +39,23 @@ namespace Rainmeter
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode)]
         private extern static IntPtr RmPathToAbsolute(IntPtr rm, string relativePath);
 
+        /// <summary>
+        /// Executes a command
+        /// </summary>
+        /// <param name="skin">Pointer to current skin (See API.GetSkin)</param>
+        /// <param name="command">Bang to execute</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// internal double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API.Execute(measure->skin, "!SetVariable SomeVar 10");  // 'measure->skin' stored previously in the Initialize function
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
         [DllImport("Rainmeter.dll", EntryPoint = "RmExecute", CharSet = CharSet.Unicode)]
         public extern static void Execute(IntPtr skin, string command);
 
@@ -41,13 +63,10 @@ namespace Rainmeter
         private extern static IntPtr RmGet(IntPtr rm, RmGetType type);
 
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int LSLog(LogType type, string unused, string message);
+        private extern static int LSLog(int type, string unused, string message);
 
         [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         private extern static int RmLog(IntPtr rm, LogType type, string message);
-
-        [DllImport("Rainmeter.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
-        private extern static int RmLogF(IntPtr rm, LogType type, string format, params string[] message);
 
         private enum RmGetType
         {
@@ -75,10 +94,13 @@ namespace Rainmeter
         /// <returns>Returns the option value as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     string value = rm.ReadString("Value", "DefaultValue");
-        ///     string action = rm.ReadString("Action", "", false);  // [MeasureNames] will be parsed/replaced when the action is executed with RmExecute
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     string value = api.ReadString("Value", "DefaultValue");
+        ///     string action = api.ReadString("Action", "", false);  // [MeasureNames] will be parsed/replaced when the action is executed with RmExecute
         /// }
         /// </code>
         /// </example>
@@ -95,9 +117,12 @@ namespace Rainmeter
         /// <returns>Returns the absolute path of the option value as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     string path = rm.ReadPath("MyPath", "C:\\");
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     string path = api.ReadPath("MyPath", "C:\\");
         /// }
         /// </code>
         /// </example>
@@ -115,9 +140,12 @@ namespace Rainmeter
         /// <returns>Returns the option value as a double</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     double value = rm.ReadDouble("Value", 20.0);
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     double value = api.ReadDouble("Value", 20.0);
         /// }
         /// </code>
         /// </example>
@@ -135,9 +163,12 @@ namespace Rainmeter
         /// <returns>Returns the option value as an integer</returns>
         /// <example>
         /// <code>
-        /// internal void Reload(Rainmeter.API rm, ref double maxValue)
+        /// [DllExport]
+        /// public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         /// {
-        ///     int value = rm.ReadInt("Value", 20);
+        ///     Measure measure = (Measure)data;
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     int value = api.ReadInt("Value", 20);
         /// }
         /// </code>
         /// </example>
@@ -153,9 +184,11 @@ namespace Rainmeter
         /// <returns>Returns a string replacing any variables in the 'str'</returns>
         /// <example>
         /// <code>
-        /// internal double Update()
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
         /// {
-        ///     string myVar = ReplaceVariables("#MyVar#").ToUpperInvariant();
+        ///     Measure measure = (Measure)data;
+        ///     string myVar = measure.api.ReplaceVariables("#MyVar#").ToUpperInvariant(); // 'measure.api' stored previously in the Initialize function
         ///     if (myVar == "SOMETHING") { return 1.0; }
         ///     return 0.0;
         /// }
@@ -173,9 +206,13 @@ namespace Rainmeter
         /// <returns>Returns the current measure name as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// [DllExport]
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     myName = GetMeasureName();  // declare 'myName' as a string in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.myName = api.GetMeasureName();  // declare 'myName' as a string in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -191,9 +228,13 @@ namespace Rainmeter
         /// <returns>Returns an IntPtr to the current skin</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// [DllExport]
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     mySkin = GetSkin();  // declare 'mySkin' as a IntPtr in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.mySkin = api.GetSkin();  // declare 'mySkin' as a IntPtr in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -203,21 +244,23 @@ namespace Rainmeter
         }
 
         /// <summary>
-        /// Retrieves a path to the Rainmeter data file (Rainmeter.data).
+        /// Retrieves a path to the Rainmeter data file (Rainmeter.data)
         /// </summary>
         /// <remarks>Call GetSettingsFile() in the Initialize function and store the results for later use</remarks>
         /// <returns>Returns the path and filename of the Rainmeter data file as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     if (rmDataFile == null) { rmDataFile = GetSettingsFile(); }  // declare 'rmDataFile' as a string in global scope
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(new Measure()));
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     if (rmDataFile == null) { rmDataFile = API.GetSettingsFile(); }  // declare 'rmDataFile' as a string in global scope
         /// }
         /// </code>
         /// </example>
-        public string GetSettingsFile()
+        public static string GetSettingsFile()
         {
-            return Marshal.PtrToStringUni(RmGet(m_Rm, RmGetType.SettingsFile));
+            return Marshal.PtrToStringUni(RmGet(IntPtr.Zero, RmGetType.SettingsFile));
         }
 
         /// <summary>
@@ -227,9 +270,13 @@ namespace Rainmeter
         /// <returns>Returns the path and filename of the skin as a string</returns>
         /// <example>
         /// <code>
-        /// internal void Initialize(Rainmeter.API rm)
+        /// [DllExport]
+        /// public static void Initialize(ref IntPtr data, IntPtr rm)
         /// {
-        ///     skinName = GetSkinName(); }  // declare 'skinName' as a string in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.skinName = api.GetSkinName(); }  // declare 'skinName' as a string in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -239,15 +286,40 @@ namespace Rainmeter
         }
 
         /// <summary>
+        /// Executes a command auto getting the skin reference
+        /// </summary>
+        /// <param name="command">Bang to execute</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     measure.api.Execute("!SetVariable SomeVar 10");  // 'measure.api' stored previously in the Initialize function
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
+        public void Execute(string command)
+        {
+            Execute(this.GetSkin(), command);
+        }
+
+        /// <summary>
         /// Returns a pointer to the handle of the skin window (HWND)
         /// </summary>
         /// <remarks>Call GetSkinWindow() in the Initialize function and store the results for later use</remarks>
         /// <returns>Returns a handle to the skin window as a IntPtr</returns>
         /// <example>
         /// <code>
+        /// [DllExport]
         /// internal void Initialize(Rainmeter.API rm)
         /// {
-        ///     skinWindow = GetSkinWindow(); }  // declare 'skinWindow' as a IntPtr in class scope
+        ///     Measure measure = new Measure();
+        ///     Rainmeter.API api = (Rainmeter.API)rm;
+        ///     measure.skinWindow = api.GetSkinWindow(); }  // declare 'skinWindow' as a IntPtr in measure class
+        ///     data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
         /// }
         /// </code>
         /// </example>
@@ -257,9 +329,9 @@ namespace Rainmeter
         }
 
         /// <summary>
-        /// DEPRECATED: Use Log(rm, type, message). Sends a message to the Rainmeter log.
+        /// DEPRECATED: Save your rm or api reference and use Log(rm, type, message). Sends a message to the Rainmeter log with no source.
         /// </summary>
-        public static void Log(LogType type, string message)
+        public static void Log(int type, string message)
         {
             LSLog(type, null, message);
         }
@@ -268,12 +340,13 @@ namespace Rainmeter
         /// Sends a message to the Rainmeter log with source
         /// </summary>
         /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
-        /// <param name="type">Log type (LOG_ERROR, LOG_WARNING, LOG_NOTICE, or LOG_DEBUG)</param>
+        /// <param name="rm">Pointer to the plugin measure</param>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
         /// <param name="message">Message to be logged</param>
         /// <returns>No return type</returns>
         /// <example>
         /// <code>
-        /// Log(rm, LOG_NOTICE, "I am a 'notice' log message with a source");
+        /// Rainmeter.API.Log(rm, API.LogType.Notice, "I am a 'notice' log message with a source");
         /// </code>
         /// </example>
         public static void Log(IntPtr rm, LogType type, string message)
@@ -282,26 +355,83 @@ namespace Rainmeter
         }
 
         /// <summary>
+        /// <summary>
         /// Sends a formatted message to the Rainmeter log
         /// </summary>
         /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
         /// <param name="rm">Pointer to the plugin measure</param>
-        /// <param name="level">Log level (LOG_ERROR, LOG_WARNING, LOG_NOTICE, or LOG_DEBUG)</param>
-        /// <param name="format">Formatted message to be logged, follows printf syntax</param>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
+        /// <param name="format">Formatted message to be logged, follows string.Format syntax</param>
         /// <param name="args">Comma separated list of args referenced in the formatted message</param>
         /// <returns>No return type</returns>
         /// <example>
         /// <code>
-        /// string notice = "notice";
-        /// LogF(rm, LOG_NOTICE, "I am a '%s' log message with a source", notice);
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     string notice = "notice";
+        ///     measure.api.LogF(measure.rm, API.LogType.Notice, "I am a '{0}' log message with a source", notice); // 'measure.rm' stored previously in the Initialize function
+        ///     
+        ///     return 0.0;
+        /// }
         /// </code>
         /// </example>
-        public static void LogF(IntPtr rm, LogType type, string format, params string[] args)
+        public static void LogF(IntPtr rm, LogType type, string format, params Object[] args)
         {
-            RmLogF(rm, type, format, args);
+            RmLog(rm, type, string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Sends a message to the Rainmeter log with source
+        /// </summary>
+        /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
+        /// <param name="message">Message to be logged</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     measure.api.Log(api, API.LogType.Notice, "I am a 'notice' log message with a source"); // 'measure.api' stored previously in the Initialize function
+        ///     
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
+        public void Log(LogType type, string message)
+        {
+            RmLog(this.m_Rm, type, message);
+        }
+
+        /// <summary>
+        /// Sends a formatted message to the Rainmeter log
+        /// </summary>
+        /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
+        /// <param name="type">Log type, use API.LogType enum (Error, Warning, Notice, or Debug)</param>
+        /// <param name="format">Formatted message to be logged, follows string.Format syntax</param>
+        /// <param name="args">Comma separated list of args referenced in the formatted message</param>
+        /// <returns>No return type</returns>
+        /// <example>
+        /// <code>
+        /// [DllExport]
+        /// public static double Update(IntPtr data)
+        /// {
+        ///     Measure measure = (Measure)data;
+        ///     string notice = "notice";
+        ///     measure.api.LogF(API.LogType.Notice, "I am a '{0}' log message with a source", notice); // 'measure.api' stored previously in the Initialize function
+        ///     
+        ///     return 0.0;
+        /// }
+        /// </code>
+        /// </example>
+        public void LogF(LogType type, string format, params Object[] args)
+        {
+            RmLog(this.m_Rm, type, string.Format(format, args));
         }
     }
-
     /// <summary>
     /// Dummy attribute to mark method as exported for DllExporter.exe.
     /// </summary>
@@ -310,6 +440,7 @@ namespace Rainmeter
     {
         public DllExport()
         {
+
         }
     }
 }

--- a/API/RainmeterAPI.h
+++ b/API/RainmeterAPI.h
@@ -146,6 +146,7 @@ enum RmGetType
 /// Sends a message to the Rainmeter log with source
 /// </summary>
 /// <remarks>LOG_DEBUG messages are logged only when Rainmeter is in debug mode</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
 /// <param name="type">Log type (LOG_ERROR, LOG_WARNING, LOG_NOTICE, or LOG_DEBUG)</param>
 /// <param name="message">Message to be logged</param>
 /// <returns>No return type</returns>
@@ -249,7 +250,7 @@ __inline double RmReadDouble(void* rm, LPCWSTR option, double defValue)
 /// <summary>
 /// Retrieves the name of the measure
 /// </summary>
-/// <remarks>Call GetMeasureName() in the Initialize function and store the results for later use</remarks>
+/// <remarks>Call RmGetMeasureName() in the Initialize function and store the results for later use</remarks>
 /// <param name="rm">Pointer to the plugin measure</param>
 /// <returns>Returns the current measure name as a string (LPCWSTR)</returns>
 /// <example>
@@ -276,7 +277,9 @@ __inline LPCWSTR RmGetMeasureName(void* rm)
 /// <code>
 /// PLUGIN_EXPORT void Initialize(void** data, void* rm)
 /// {
-/// 	if (rmDataFile == nullptr) { rmDataFile = RmGetSettingsFile(); }  // 'rmDataFile' defined as a string (LPCWSTR) in global scope
+/// 	Measure* measure = new Measure;
+/// 	*data = measure;
+///		if (rmDataFile == nullptr) { rmDataFile = RmGetSettingsFile(); }  // 'rmDataFile' defined as a string (LPCWSTR) in global scope
 /// }
 /// </code>
 /// </example>
@@ -310,6 +313,7 @@ __inline void* RmGetSkin(void* rm)
 /// Retrieves full path and name of the skin
 /// </summary>
 /// <remarks>Call GetSkinName() in the Initialize function and store the results for later use</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
 /// <returns>Returns the path and filename of the skin as a string (LPCWSTR)</returns>
 /// <example>
 /// <code>
@@ -330,6 +334,7 @@ __inline LPCWSTR RmGetSkinName(void* rm)
 /// Returns a pointer to the handle of the skin window (HWND)
 /// </summary>
 /// <remarks>Call GetSkinWindow() in the Initialize function and store the results for later use</remarks>
+/// <param name="rm">Pointer to the plugin measure</param>
 /// <returns>Returns a handle to the skin window as a HWND</returns>
 /// <example>
 /// <code>

--- a/C#/PluginDataHandling/AssemblyInfo.cs
+++ b/C#/PluginDataHandling/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyCopyright("© 2014 - YOUR NAME")]
+[assembly: AssemblyVersion("1.0.0.0")]
+
+// Do not change the entries below!
+#if X64
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (64-bit)")]
+#else
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (32-bit)")]
+#endif
+[assembly: AssemblyProduct("Rainmeter")]

--- a/C#/PluginDataHandling/PluginDataHandling.cs
+++ b/C#/PluginDataHandling/PluginDataHandling.cs
@@ -1,0 +1,158 @@
+﻿/*
+Copyright (C) 2017 Trevor Hamilton
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Rainmeter;
+
+// Overview: This example demonstrates using both the data argument to keep data across
+// functions calls and also storing data in the Rainmeter.Data file for presistance across
+// skin reloads and even measures. In this example we will make a counter that counts the
+// number of updates that happens and saves them on Finalize to the Rainmeter.data
+// Note: You should never rely on Update happening at the exact time you specify
+
+// Sample skin:
+/*
+[Rainmeter]
+Update=1000
+DynamicWindowSize=1
+BackgroundMode=2
+SolidColor=255,255,255
+
+[mCount]
+Measure=Plugin
+Plugin=DataHandling.dll
+StoreData=1
+
+[TextCount]
+Meter=String
+MeasureName=mCount
+X=0
+Y=0R
+FontSize=20
+Text=%1
+
+[mCountAt0]
+Measure=Plugin
+Plugin=DataHandling.dll
+StartingValue=0
+
+[TextCountAt0]
+Meter=String
+MeasureName=mCountAt0
+X=0
+Y=0R
+FontSize=20
+Text=%1
+*/
+
+namespace PluginDataHandling
+{
+    class Measure
+    {
+        static public implicit operator Measure(IntPtr data)
+        {
+            return (Measure)GCHandle.FromIntPtr(data).Target;
+        }
+        public int myCounter = 0;
+        public bool storeData = false;
+    }
+
+    public class Plugin
+    {
+        //Used for reading and writing values from the rainmeter settings file
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        static extern int GetPrivateProfileString(string section, string key, string defaultValue,
+            [In, Out] char[] value, int size, string filePath);
+
+        [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool WritePrivateProfileString(string section, string key,
+            string value, string filePath);
+
+        static string PluginName = "DataHandling"; //Always match this to your plugin name
+        static string KeyName = "StoredCount"; //You can have multiple keys for your plugin that you store different info under
+        const int MAXSIZE = 256;
+
+        [DllExport]
+        public static void Initialize(ref IntPtr data, IntPtr rm)
+        {
+            data = GCHandle.ToIntPtr(GCHandle.Alloc(new Measure()));
+        }
+
+        [DllExport]
+        public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
+        {
+            Measure measure = (Measure)data;
+            Rainmeter.API api = (Rainmeter.API)rm;
+
+            //Get starting value if one is defined
+            int startValue = api.ReadInt("StartingValue", -1);
+
+            //If string from option was null read from file
+            if (startValue == -1)
+            {
+                char[] outString = new char[MAXSIZE];
+
+                //Read from Rainmeter.data file, if no instace exists start at 0
+                GetPrivateProfileString(PluginName, KeyName, "0", outString, MAXSIZE, API.GetSettingsFile());
+
+                try
+                {
+                    //Need try catch just in case someone tampers with the file and the value stored is not a number
+                    string intString = new string(outString);
+                    measure.myCounter = Convert.ToInt32(intString);
+                }
+                catch
+                {
+                    api.Log(API.LogType.Error, "Error converting value stored in Rainmeter.data to integer");
+                }
+            }
+            else
+            {
+                measure.myCounter = startValue;
+            }
+
+            //If store data is 1 then save data when measure is unloaded
+            measure.storeData = api.ReadInt("StoreData", 0) == 1 ? true : false;
+        }
+
+        [DllExport]
+        public static double Update(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+
+            return ++measure.myCounter;
+        }
+
+        [DllExport]
+        public static void Finalize(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+
+            //Note that in this example if multiple measures have store data set to true whichever unloads last's data will persist
+            if (measure.storeData)
+            {
+                WritePrivateProfileString(PluginName, KeyName, measure.myCounter.ToString(), API.GetSettingsFile());
+            }
+
+            GCHandle.FromIntPtr(data).Free();
+        }
+    }
+}

--- a/C#/PluginDataHandling/PluginDataHandling.csproj
+++ b/C#/PluginDataHandling/PluginDataHandling.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PluginDataHandling</RootNamespace>
+    <AssemblyName>DataHandling</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>x32\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>x32\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>x64\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;X64</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>x64\Release\</OutputPath>
+    <DefineConstants>TRACE;X64</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>Always</RunPostBuildEvent>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="PluginDataHandling.cs" />
+    <Compile Include="$(SolutionDir)..\API\RainmeterAPI.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <PropertyGroup>
+    <PostBuildEvent>"$(SolutionDir)..\API\DllExporter.exe" "$(ConfigurationName)" "$(PlatformName)" "$(TargetDir)\" "$(TargetFileName)"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/C#/PluginEmpty/PluginEmpty.cs
+++ b/C#/PluginEmpty/PluginEmpty.cs
@@ -66,7 +66,7 @@ namespace PluginEmpty
 
         //[DllExport]
         //public static IntPtr (IntPtr data, int argc,
-        //    [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
+        //    [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] string[] argv)
         //{
         //    Measure measure = (Measure)data;
         //

--- a/C#/PluginEmpty/PluginEmpty.cs
+++ b/C#/PluginEmpty/PluginEmpty.cs
@@ -1,6 +1,8 @@
 ﻿// Uncomment these only if you want to export GetString() or ExecuteBang().
 //#define DLLEXPORT_GETSTRING
 //#define DLLEXPORT_EXECUTEBANG
+// Uncomment only if you want to expose functions to use as section variables
+//#define DLLEXPORT_SECTIONVARIABLES
 
 using System;
 using System.Collections.Generic;
@@ -44,6 +46,18 @@ namespace PluginEmpty
         {
         }
 #endif
+#if DLLEXPORT_SOMEFUNCTION
+        internal bool SomeFunction(IntPtr data, out string retValue, int argc, string[] argv)
+        {
+            retValue = "";
+            return true;
+        }
+        internal bool SomeFunction2(IntPtr data, out string retValue, int argc, string[] argv)
+        {
+            retValue = "";
+            return true;
+        }
+#endif
     }
 
     public static class Plugin
@@ -85,7 +99,7 @@ namespace PluginEmpty
             Measure measure = (Measure)GCHandle.FromIntPtr(data).Target;
             return measure.Update();
         }
-        
+
 #if DLLEXPORT_GETSTRING
         [DllExport]
         public static IntPtr GetString(IntPtr data)
@@ -113,6 +127,20 @@ namespace PluginEmpty
         {
             Measure measure = (Measure)GCHandle.FromIntPtr(data).Target;
             measure.ExecuteBang(Marshal.PtrToStringUni(args));
+        }
+//#endif
+//#if DLLEXPORT_SECTIONVARIABLES
+        [DllExport]
+        public static bool SomeFunction(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)] out string retValue, int argc,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
+        {
+            return SomeFunction(data, out retValue, argc, argv);
+        }
+        [DllExport]
+        public static bool SomeFunction2(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)] out string retValue, int argc,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
+        {
+            return SomeFunction2(data, out retValue, argc, argv);
         }
 #endif
     }

--- a/C#/PluginEmpty/PluginEmpty.cs
+++ b/C#/PluginEmpty/PluginEmpty.cs
@@ -1,6 +1,7 @@
-﻿// Uncomment these only if you want to export GetString() or ExecuteBang().
+﻿// Uncomment these only if you want to export GetString(), ExecuteBang(), or plan to add support for section variables.
 //#define DLLEXPORT_GETSTRING
 //#define DLLEXPORT_EXECUTEBANG
+//#define DLLEXPORT_SECTIONVARIABLES
 
 using System;
 using System.Collections.Generic;
@@ -9,110 +10,81 @@ using Rainmeter;
 
 // Overview: This is a blank canvas on which to build your plugin.
 
-// Note: Measure.GetString, Plugin.GetString, Measure.ExecuteBang, and
-// Plugin.ExecuteBang have been commented out. If you need GetString
-// and/or ExecuteBang and you have read what they are used for from the
-// SDK docs, uncomment the function(s). Otherwise leave them commented out
-// (or get rid of them)!
+// Note: GetString, ExecuteBang and an unnamed function for use as a section variable
+// have been commented out. If you need GetString, ExecuteBang, and/or section variables 
+// and you have read what they are used for from the SDK docs, uncomment the function(s)
+// and/or add a function name to use for the section variable function(s). 
+// Otherwise leave them commented out (or get rid of them)!
 
 namespace PluginEmpty
 {
-    internal class Measure
+    class Measure
     {
-        internal Measure()
+        static public implicit operator Measure(IntPtr data)
         {
+            return (Measure)GCHandle.FromIntPtr(data).Target;
         }
 
-        internal void Reload(Rainmeter.API api, ref double maxValue)
-        {
-        }
-
-        internal double Update()
-        {
-            return 0.0;
-        }
-        
 #if DLLEXPORT_GETSTRING
-        internal string GetString()
-        {
-            return "";
-        }
-#endif
-        
-#if DLLEXPORT_EXECUTEBANG
-        internal void ExecuteBang(string args)
-        {
-        }
+        public String StringBuffer;
 #endif
     }
 
-    public static class Plugin
+    public class Plugin
     {
-#if DLLEXPORT_GETSTRING
-        static IntPtr StringBuffer = IntPtr.Zero;
-#endif
-
         [DllExport]
         public static void Initialize(ref IntPtr data, IntPtr rm)
         {
             data = GCHandle.ToIntPtr(GCHandle.Alloc(new Measure()));
+            Rainmeter.API api = (Rainmeter.API)rm;
         }
 
         [DllExport]
         public static void Finalize(IntPtr data)
         {
             GCHandle.FromIntPtr(data).Free();
-            
-#if DLLEXPORT_GETSTRING
-            if (StringBuffer != IntPtr.Zero)
-            {
-                Marshal.FreeHGlobal(StringBuffer);
-                StringBuffer = IntPtr.Zero;
-            }
-#endif
         }
 
         [DllExport]
         public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
         {
-            Measure measure = (Measure)GCHandle.FromIntPtr(data).Target;
-            measure.Reload(new Rainmeter.API(rm), ref maxValue);
+            Measure measure = (Measure)data;
         }
 
         [DllExport]
         public static double Update(IntPtr data)
         {
-            Measure measure = (Measure)GCHandle.FromIntPtr(data).Target;
-            return measure.Update();
+            Measure measure = (Measure)data;
+
+            return 0.0;
         }
-        
+
 #if DLLEXPORT_GETSTRING
         [DllExport]
         public static IntPtr GetString(IntPtr data)
         {
-            Measure measure = (Measure)GCHandle.FromIntPtr(data).Target;
-            if (StringBuffer != IntPtr.Zero)
-            {
-                Marshal.FreeHGlobal(StringBuffer);
-                StringBuffer = IntPtr.Zero;
-            }
+            Measure measure = (Measure)data;
 
-            string stringValue = measure.GetString();
-            if (stringValue != null)
-            {
-                StringBuffer = Marshal.StringToHGlobalUni(stringValue);
-            }
-
-            return StringBuffer;
+            return Marshal.StringToHGlobalUni(""); //IntPtr.Zero will result in it not being used
         }
 #endif
 
 #if DLLEXPORT_EXECUTEBANG
         [DllExport]
-        public static void ExecuteBang(IntPtr data, IntPtr args)
+        public static void ExecuteBang(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)]String args)
         {
-            Measure measure = (Measure)GCHandle.FromIntPtr(data).Target;
-            measure.ExecuteBang(Marshal.PtrToStringUni(args));
+            Measure measure = (Measure)data;
+        }
+#endif
+
+#if DLLEXPORT_SECTIONVARIABLES
+        [DllExport]
+        public static IntPtr (IntPtr data, int argc,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
+        {
+            Measure measure = (Measure)data;
+
+            return Marshal.StringToHGlobalUni(""); //IntPtr.Zero will result in it not being used
         }
 #endif
     }

--- a/C#/PluginEmpty/PluginEmpty.cs
+++ b/C#/PluginEmpty/PluginEmpty.cs
@@ -1,9 +1,4 @@
-﻿// Uncomment these only if you want to export GetString(), ExecuteBang(), or plan to add support for section variables.
-//#define DLLEXPORT_GETSTRING
-//#define DLLEXPORT_EXECUTEBANG
-//#define DLLEXPORT_SECTIONVARIABLES
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Rainmeter;
@@ -24,10 +19,6 @@ namespace PluginEmpty
         {
             return (Measure)GCHandle.FromIntPtr(data).Target;
         }
-
-#if DLLEXPORT_GETSTRING
-        public String StringBuffer;
-#endif
     }
 
     public class Plugin
@@ -59,33 +50,27 @@ namespace PluginEmpty
             return 0.0;
         }
 
-#if DLLEXPORT_GETSTRING
-        [DllExport]
-        public static IntPtr GetString(IntPtr data)
-        {
-            Measure measure = (Measure)data;
+        //[DllExport]
+        //public static IntPtr GetString(IntPtr data)
+        //{
+        //    Measure measure = (Measure)data;
+        //
+        //    return Marshal.StringToHGlobalUni(""); //returning IntPtr.Zero will result in it not being used
+        //}
 
-            return Marshal.StringToHGlobalUni(""); //IntPtr.Zero will result in it not being used
-        }
-#endif
+        //[DllExport]
+        //public static void ExecuteBang(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)]String args)
+        //{
+        //    Measure measure = (Measure)data;
+        //}
 
-#if DLLEXPORT_EXECUTEBANG
-        [DllExport]
-        public static void ExecuteBang(IntPtr data, [MarshalAs(UnmanagedType.LPWStr)]String args)
-        {
-            Measure measure = (Measure)data;
-        }
-#endif
-
-#if DLLEXPORT_SECTIONVARIABLES
-        [DllExport]
-        public static IntPtr (IntPtr data, int argc,
-            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
-        {
-            Measure measure = (Measure)data;
-
-            return Marshal.StringToHGlobalUni(""); //IntPtr.Zero will result in it not being used
-        }
-#endif
+        //[DllExport]
+        //public static IntPtr (IntPtr data, int argc,
+        //    [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] argv)
+        //{
+        //    Measure measure = (Measure)data;
+        //
+        //    return Marshal.StringToHGlobalUni(""); //returning IntPtr.Zero will result in it not being used
+        //}
     }
 }

--- a/C#/PluginParentChild/PluginParentChild.cs
+++ b/C#/PluginParentChild/PluginParentChild.cs
@@ -105,7 +105,7 @@ namespace PluginParentChild
                     break;
 
                 default:
-                    API.Log(API.LogType.Error, "ParentChild.dll: Type=" + type + " not valid");
+                    api.Log(API.LogType.Error, "ParentChild.dll: Type=" + type + " not valid");
                     break;
             }
         }
@@ -196,7 +196,7 @@ namespace PluginParentChild
 
             if (ParentMeasure == null)
             {
-                API.Log(API.LogType.Error, "ParentChild.dll: ParentName=" + parentName + " not valid");
+                api.Log(API.LogType.Error, "ParentChild.dll: ParentName=" + parentName + " not valid");
             }
         }
 

--- a/C#/PluginRmExecute/AssemblyInfo.cs
+++ b/C#/PluginRmExecute/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyCopyright("© 2014 - YOUR NAME")]
+[assembly: AssemblyVersion("1.0.0.0")]
+
+// Do not change the entries below!
+#if X64
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (64-bit)")]
+#else
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (32-bit)")]
+#endif
+[assembly: AssemblyProduct("Rainmeter")]

--- a/C#/PluginRmExecute/PluginRmExecute.cs
+++ b/C#/PluginRmExecute/PluginRmExecute.cs
@@ -1,0 +1,141 @@
+﻿/*
+Copyright (C) 2017 Trevor Hamilton
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Rainmeter;
+
+// Overview: This is an example of how to make an option be read and execute the bang within.
+// It also showcases how you can get some of the affects of DynamicVariables=1 without as much
+// of a performance hit. As well it also shows why you should be careful of skins turning on DV=1
+
+// Sample skin:
+/*
+[Rainmeter]
+Update=1000
+DynamicWindowSize=1
+BackgroundMode=2
+SolidColor=255,255,255
+
+[Variables]
+Count=0
+Timer=5
+
+;This measure will change TextCount after #Timer# seconds
+[mTimer]
+Measure=Plugin
+Plugin=RmExecute.dll
+Timer=#Timer#
+OnTimer=[!SetOption TextCount Text "This text has changed!"]
+
+[TextCount]
+Meter=String
+X=0
+Y=0R
+FontSize=20
+Text=This text has not changed yet.
+
+[mTimerC]
+Measure=Plugin
+Plugin=RmExecute.dll
+Timer=#Timer#
+;Notice how we can even do more complex bangs.
+;If you uncomment the code in update the variable reference will even autoupdate without DynamicVariables=1
+;Or you could just uncomment DynamicVariables=1
+OnTimer=[!SetVariable Count "(#Count#+1)"][!SetOption TextCountC Text "This text has been updated #Count# times"]
+;DynamicVariables=1
+
+[TextCountC]
+Meter=String
+X=0
+Y=0R
+FontSize=20
+Text=This text has been updated #Count# times
+*/
+
+namespace PluginRmExecute
+{
+    class Measure
+    {
+        static public implicit operator Measure(IntPtr data)
+        {
+            return (Measure)GCHandle.FromIntPtr(data).Target;
+        }
+        public string myCommand = "";
+        public int updateRate;
+        public DateTime timer;
+
+        public Rainmeter.API api;
+    }
+
+    public class Plugin
+    {
+        [DllExport]
+        public static void Initialize(ref IntPtr data, IntPtr rm)
+        {
+            Measure measure = new Measure();
+            Rainmeter.API api = (Rainmeter.API)rm;
+
+            measure.api = api;
+
+            //We do this in Initialize so that if a skin were to turn on DynamicVariables it will not break the plugin
+            measure.timer = DateTime.UtcNow;
+
+            data = GCHandle.ToIntPtr(GCHandle.Alloc(measure));
+        }
+
+        [DllExport]
+        public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
+        {
+            Measure measure = (Measure)data;
+            Rainmeter.API api = (Rainmeter.API)rm;
+
+            measure.updateRate = api.ReadInt("Timer", 1);
+            //We dont have to replace measures here as they will be replaced during Execute so we can pass false. 
+            //Note though that doing that measures will always then have their current info in update but variables will not. See the commented out code below to have both always act like DynamicVariables=1
+            measure.myCommand = api.ReadString("OnTimer", "", false);
+        }
+
+        [DllExport]
+        public static double Update(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+
+            int timePassed = (int)(DateTime.UtcNow - measure.timer).TotalSeconds;
+
+            if(timePassed >= measure.updateRate)
+            {
+                //We could also do something like this to get DynamicVariables without the need to turn them on. Uncomment this to see the second example work
+                //measure.myCommand = measure.api.ReadString("OnTimer", "", false);
+
+                measure.api.Execute(measure.myCommand);
+                measure.timer = DateTime.UtcNow;
+            }
+
+            //Even if you don't plan for users to use it returning a value can be useful for helping with skin debugging
+            return measure.updateRate - timePassed;
+        }
+
+        [DllExport]
+        public static void Finalize(IntPtr data)
+        {
+            GCHandle.FromIntPtr(data).Free();
+        }
+    }
+}

--- a/C#/PluginRmExecute/PluginRmExecute.csproj
+++ b/C#/PluginRmExecute/PluginRmExecute.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4AA459BF-425E-40F5-AE31-5EE97304C538}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PluginRmExecute</RootNamespace>
+    <AssemblyName>RmExecute</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>x32\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>x32\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>x64\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;X64</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>x64\Release\</OutputPath>
+    <DefineConstants>TRACE;X64</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>Always</RunPostBuildEvent>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="PluginRmExecute.cs" />
+    <Compile Include="$(SolutionDir)..\API\RainmeterAPI.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <PropertyGroup>
+    <PostBuildEvent>"$(SolutionDir)..\API\DllExporter.exe" "$(ConfigurationName)" "$(PlatformName)" "$(TargetDir)\" "$(TargetFileName)"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/C#/PluginSectionVariables/AssemblyInfo.cs
+++ b/C#/PluginSectionVariables/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyCopyright("© 2014 - YOUR NAME")]
+[assembly: AssemblyVersion("1.0.0.0")]
+
+// Do not change the entries below!
+#if X64
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (64-bit)")]
+#else
+[assembly: AssemblyInformationalVersion("3.0.2.2161 (32-bit)")]
+#endif
+[assembly: AssemblyProduct("Rainmeter")]

--- a/C#/PluginSectionVariables/PluginSectionVariables.cs
+++ b/C#/PluginSectionVariables/PluginSectionVariables.cs
@@ -1,0 +1,147 @@
+﻿/*
+Copyright (C) 2017 Trevor Hamilton
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+using System;
+using System.Runtime.InteropServices;
+using Rainmeter;
+
+// Overview: This example demonstrates using plugin section variables, aka calling a plugin inline.
+// In this example we build a ToUpper and a ToLower section variable that can either get the measure text 
+// or transform the string passed to uppercase/lowercase
+
+// Sample skin:
+/*
+[Rainmeter]
+Update=1000
+DynamicWindowSize=1
+BackgroundMode=2
+SolidColor=255,255,255
+
+[Variables]
+;You can't get a Meter's text so use a variable
+TextString=Click me to make me uppercase!
+
+[mString]
+Measure=Plugin
+Plugin=SectionVariables.dll
+Input=I come from the measure reference!
+
+[TextLower]
+Meter=String
+X=0
+Y=0
+FontSize=20
+;Notice how we need DynamicVariable=1 since section variables can not be called on initialize
+Text=[&mString:ToLower()]
+DynamicVariables=1
+
+[TextUpper]
+Meter=String
+X=0
+Y=0R
+FontSize=20
+Text=#TextString#
+;Notice how we don't need DynamicVariables=1 if we set the text manually
+LeftMouseUpAction=[!SetOption TextUpper Text "[&mString:ToUpper(#TextString#)]"]
+*/
+
+namespace PluginSectionVariables
+{
+    class Measure
+    {
+        static public implicit operator Measure(IntPtr data)
+        {
+            return (Measure)GCHandle.FromIntPtr(data).Target;
+        }
+        public string myString; //The string returned in GetString is stored here
+    }
+
+    public class Plugin
+    {
+        [DllExport]
+        public static void Initialize(ref IntPtr data, IntPtr rm)
+        {
+            data = GCHandle.ToIntPtr(GCHandle.Alloc(new Measure()));
+            Rainmeter.API api = (Rainmeter.API)rm;
+        }
+
+        [DllExport]
+        public static void Reload(IntPtr data, IntPtr rm, ref double maxValue)
+        {
+            Measure measure = (Measure)data;
+            Rainmeter.API api = (Rainmeter.API)rm;
+
+            //Read measure for an Input string
+            measure.myString = api.ReadString("Input", "");
+        }
+
+        [DllExport]
+        public static double Update(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+            return 0.0;
+        }
+
+        [DllExport]
+        public static IntPtr GetString(IntPtr data)
+        {
+            Measure measure = (Measure)data;
+            return Marshal.StringToHGlobalUni(measure.myString);
+        }
+
+        //If you are comparing this to the C++ example a stringBuffer is not needed since Marshal handles that
+
+        [DllExport]
+        public static IntPtr ToUpper(IntPtr data, int argc,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] string[] argv)
+        {
+            Measure measure = (Measure)data;
+
+            //If we are given one or more arguments convert to uppercase the first one
+            if (argc > 0)
+            {
+                return Marshal.StringToHGlobalUni(argv[0].ToUpper());
+            }
+
+            //If we are given no arguments  convert to uppercase the string we recived with the input option
+            return Marshal.StringToHGlobalUni(measure.myString.ToUpper());
+        }
+
+        [DllExport]
+        public static IntPtr ToLower(IntPtr data, int argc,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] string[] argv)
+        {
+            Measure measure = (Measure)data;
+
+            //If we are given one or more arguments convert to lowercase the first one
+            if (argc > 0)
+            {
+                return Marshal.StringToHGlobalUni(argv[0].ToLower());
+            }
+
+            //If we are given no arguments  convert to lowercase the string we recived with the input option
+            return Marshal.StringToHGlobalUni(measure.myString.ToLower());
+        }
+
+        [DllExport]
+        public static void Finalize(IntPtr data)
+        {
+            GCHandle.FromIntPtr(data).Free();
+        }
+    }
+}

--- a/C#/PluginSectionVariables/PluginSectionVariables.csproj
+++ b/C#/PluginSectionVariables/PluginSectionVariables.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PluginSectionVariables</RootNamespace>
+    <AssemblyName>SectionVariables</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>x32\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>x32\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>x64\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;X64</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>x64\Release\</OutputPath>
+    <DefineConstants>TRACE;X64</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <NoWarn>1607</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>Always</RunPostBuildEvent>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="PluginSectionVariables.cs" />
+    <Compile Include="$(SolutionDir)..\API\RainmeterAPI.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <PropertyGroup>
+    <PostBuildEvent>"$(SolutionDir)..\API\DllExporter.exe" "$(ConfigurationName)" "$(PlatformName)" "$(TargetDir)\" "$(TargetFileName)"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/C#/PluginSystemVersion/PluginSystemVersion.cs
+++ b/C#/PluginSystemVersion/PluginSystemVersion.cs
@@ -96,9 +96,9 @@ namespace PluginSystemVersion
         {
         }
 
-        internal void Reload(Rainmeter.API rm, ref double maxValue)
+        internal void Reload(Rainmeter.API api, ref double maxValue)
         {
-            string type = rm.ReadString("Type", "");
+            string type = api.ReadString("Type", "");
             switch (type.ToLowerInvariant())
             {
                 case "major":
@@ -118,7 +118,7 @@ namespace PluginSystemVersion
                     break;
 
                 default:
-                    API.Log(API.LogType.Error, "SystemVersion.dll: Type=" + type + " not valid");
+                    api.Log(API.LogType.Error, "SystemVersion.dll: Type=" + type + " not valid");
                     break;
             }
         }

--- a/C#/SDK-CS.sln
+++ b/C#/SDK-CS.sln
@@ -1,11 +1,19 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2013
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.10
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginEmpty", "PluginEmpty\PluginEmpty.csproj", "{D31F73ED-3978-44FA-B599-49584BA30D3A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginParentChild", "PluginParentChild\PluginParentChild.csproj", "{CA8F01AC-9582-4820-AA24-919EC747536E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginSystemVersion", "PluginSystemVersion\PluginSystemVersion.csproj", "{F43D0210-4CED-49B0-93C4-C694EFB44282}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginDataHandling", "PluginDataHandling\PluginDataHandling.csproj", "{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginRmExecute", "PluginRmExecute\PluginRmExecute.csproj", "{4AA459BF-425E-40F5-AE31-5EE97304C538}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginSectionVariables", "PluginSectionVariables\PluginSectionVariables.csproj", "{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,8 +47,35 @@ Global
 		{F43D0210-4CED-49B0-93C4-C694EFB44282}.Release|x64.Build.0 = Release|x64
 		{F43D0210-4CED-49B0-93C4-C694EFB44282}.Release|x86.ActiveCfg = Release|x86
 		{F43D0210-4CED-49B0-93C4-C694EFB44282}.Release|x86.Build.0 = Release|x86
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Debug|x64.ActiveCfg = Debug|x64
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Debug|x64.Build.0 = Debug|x64
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Debug|x86.ActiveCfg = Debug|x86
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Debug|x86.Build.0 = Debug|x86
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Release|x64.ActiveCfg = Release|x64
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Release|x64.Build.0 = Release|x64
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Release|x86.ActiveCfg = Release|x86
+		{29C1A579-28E6-4D9C-BA9C-BECF4EFEB759}.Release|x86.Build.0 = Release|x86
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Debug|x64.ActiveCfg = Debug|x64
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Debug|x64.Build.0 = Debug|x64
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Debug|x86.ActiveCfg = Debug|x86
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Debug|x86.Build.0 = Debug|x86
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Release|x64.ActiveCfg = Release|x64
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Release|x64.Build.0 = Release|x64
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Release|x86.ActiveCfg = Release|x86
+		{4AA459BF-425E-40F5-AE31-5EE97304C538}.Release|x86.Build.0 = Release|x86
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Debug|x64.ActiveCfg = Debug|x64
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Debug|x64.Build.0 = Debug|x64
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Debug|x86.ActiveCfg = Debug|x86
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Debug|x86.Build.0 = Debug|x86
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Release|x64.ActiveCfg = Release|x64
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Release|x64.Build.0 = Release|x64
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Release|x86.ActiveCfg = Release|x86
+		{4F74D778-91E1-4CB6-974A-8B0C2D5B9C09}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8AD0A00D-365F-48B7-B112-6A1AFE13C535}
 	EndGlobalSection
 EndGlobal

--- a/C++/PluginDataHandling/PluginDataHandling.cpp
+++ b/C++/PluginDataHandling/PluginDataHandling.cpp
@@ -1,0 +1,125 @@
+/*
+Copyright (C) 2017 Trevor Hamilton
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#include <Windows.h>
+#include "../../API/RainmeterAPI.h"
+
+// Overview: This example demonstrates using both the data argument to keep data across
+// functions calls and also storing data in the Rainmeter.Data file for presistance across
+// skin reloads and even measures. In this example we will make a counter that counts the
+// number of updates that happens and saves them on Finalize to the Rainmeter.data
+// Note: You should never rely on Update happening at the exact time you specify
+
+// Sample skin:
+/*
+[Rainmeter]
+Update=1000
+DynamicWindowSize=1
+BackgroundMode=2
+SolidColor=255,255,255
+
+[mCount]
+Measure=Plugin
+Plugin=DataHandling.dll
+StoreData=1
+
+[TextCount]
+Meter=String
+MeasureName=mCount
+X=0
+Y=0R
+FontSize=20
+Text=%1
+
+[mCountAt0]
+Measure=Plugin
+Plugin=DataHandling.dll
+StartingValue=0
+
+[TextCountAt0]
+Meter=String
+MeasureName=mCountAt0
+X=0
+Y=0R
+FontSize=20
+Text=%1
+*/
+
+struct Measure
+{
+	Measure() {}
+	int myCounter = 0;
+	bool storeData = false;
+};
+
+LPCWSTR PluginName = L"DataHandling"; //Always match this to your plugin name
+LPCWSTR KeyName = L"StoredCount";
+const int MAXSIZE = 256;
+
+PLUGIN_EXPORT void Initialize(void** data, void* rm)
+{
+	Measure* measure = new Measure;
+	*data = measure;
+}
+
+PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+{
+	Measure* measure = (Measure*)data;
+
+	//Get starting value if one is defined
+	LPCWSTR startValue = RmReadString(rm, L"StartingValue", NULL);
+
+	//If string from option was null read from file
+	if (!startValue || !startValue[0])
+	{
+		LPTSTR outString = new TCHAR[MAXSIZE];
+
+		//Read from Rainmeter.data file, if no instace exists start at 0
+		GetPrivateProfileString(PluginName, KeyName, L"0", outString, MAXSIZE, RmGetSettingsFile());
+		measure->myCounter = _wtoi(outString);
+	}
+	else
+	{
+		measure->myCounter = _wtoi(startValue);
+	}
+	//If store data starts with 1 then save data when measure is unloaded
+	measure->storeData = RmReadString(rm, L"StoreData", L"0")[0] == L'1' ? true : false;
+}
+
+PLUGIN_EXPORT double Update(void* data)
+{
+	Measure* measure = (Measure*)data;
+
+	//Notice how the every measure has its own counter since it gets it from data
+	return ++measure->myCounter;
+}
+
+PLUGIN_EXPORT void Finalize(void* data)
+{
+	Measure* measure = (Measure*)data;
+
+	//Note that in this example if multiple measures have store data set to true whichever unloads last's data will persist
+	if (measure->storeData)
+	{
+		wchar_t buffer[MAXSIZE];
+		wsprintfW(buffer, L"%d", measure->myCounter);
+		WritePrivateProfileString(PluginName, KeyName, buffer, RmGetSettingsFile());
+	}
+
+	delete measure;
+}

--- a/C++/PluginDataHandling/PluginDataHandling.cpp
+++ b/C++/PluginDataHandling/PluginDataHandling.cpp
@@ -68,7 +68,7 @@ struct Measure
 };
 
 LPCWSTR PluginName = L"DataHandling"; //Always match this to your plugin name
-LPCWSTR KeyName = L"StoredCount";
+LPCWSTR KeyName = L"StoredCount"; //You can have multiple keys for your plugin that you store different info under
 const int MAXSIZE = 256;
 
 PLUGIN_EXPORT void Initialize(void** data, void* rm)

--- a/C++/PluginDataHandling/PluginDataHandling.cpp
+++ b/C++/PluginDataHandling/PluginDataHandling.cpp
@@ -82,10 +82,10 @@ PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
 	Measure* measure = (Measure*)data;
 
 	//Get starting value if one is defined
-	LPCWSTR startValue = RmReadString(rm, L"StartingValue", NULL);
+	int startValue = RmReadInt(rm, L"StartingValue", -1);
 
 	//If string from option was null read from file
-	if (!startValue || !startValue[0])
+	if (startValue == -1)
 	{
 		LPTSTR outString = new TCHAR[MAXSIZE];
 
@@ -95,10 +95,10 @@ PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
 	}
 	else
 	{
-		measure->myCounter = _wtoi(startValue);
+		measure->myCounter = startValue;
 	}
-	//If store data starts with 1 then save data when measure is unloaded
-	measure->storeData = RmReadString(rm, L"StoreData", L"0")[0] == L'1' ? true : false;
+	//If store data is 1 then save data when measure is unloaded
+	measure->storeData = RmReadInt(rm, L"StoreData", 0) == 1 ? true : false;
 }
 
 PLUGIN_EXPORT double Update(void* data)

--- a/C++/PluginDataHandling/PluginDataHandling.filters
+++ b/C++/PluginDataHandling/PluginDataHandling.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ResourceCompile Include="PluginDataHandling.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PluginDataHandling.cpp" />
+  </ItemGroup>
+</Project>

--- a/C++/PluginDataHandling/PluginDataHandling.rc
+++ b/C++/PluginDataHandling/PluginDataHandling.rc
@@ -1,0 +1,43 @@
+#define APSTUDIO_READONLY_SYMBOLS
+#include <windows.h>
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION 3,0,2,2161
+ FILEFLAGSMASK 0x17L
+#ifdef _DEBUG
+ FILEFLAGS VS_FF_DEBUG
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS	VOS_NT_WINDOWS32
+ FILETYPE VFT_DLL
+ FILESUBTYPE VFT_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "FileVersion", "1.0.0.0"
+            VALUE "LegalCopyright", "© 2014 - YOUR NAME"
+
+            // Don't change the entries below!
+            VALUE "ProductName", "Rainmeter"
+#ifdef _WIN64
+            VALUE "ProductVersion", "3.0.2.2161 (64-bit)"
+#else
+            VALUE "ProductVersion", "3.0.2.2161 (32-bit)"
+#endif //_WIN64
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END

--- a/C++/PluginDataHandling/PluginDataHandling.vcxproj
+++ b/C++/PluginDataHandling/PluginDataHandling.vcxproj
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="PluginDataHandling.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PluginDataHandling.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>PluginDataHandling</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>DataHandling</TargetName>
+    <OutDir>x32\$(Configuration)\</OutDir>
+    <IntDir>x32\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>DataHandling</TargetName>
+    <OutDir>x64\$(Configuration)\</OutDir>
+    <IntDir>x64\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>DataHandling</TargetName>
+    <OutDir>x32\$(Configuration)\</OutDir>
+    <IntDir>x32\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>DataHandling</TargetName>
+    <OutDir>x64\$(Configuration)\</OutDir>
+    <IntDir>x64\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\API\x32\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\API\x64\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <PostBuildEvent>
+      <Command>taskkill /f /fi "imagename eq Rainmeter.exe"
+xcopy  "$(TargetDir)$(TargetFileName)" "%appdata%\Rainmeter\Plugins" /Y</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <MergeSections>.rdata=.text</MergeSections>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\API\x32\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <MergeSections>.rdata=.text</MergeSections>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\API\x64\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/C++/PluginEmpty/PluginEmpty.cpp
+++ b/C++/PluginEmpty/PluginEmpty.cpp
@@ -3,10 +3,11 @@
 
 // Overview: This is a blank canvas on which to build your plugin.
 
-// Note: GetString and ExecuteBang have been commented out. If you need
-// GetString and/or ExecuteBang and you have read what they are used for
-// from the SDK docs, uncomment the function(s). Otherwise leave them
-// commented out (or get rid of them)!
+// Note: GetString, ExecuteBang and an unnamed function for use as a section variable
+// have been commented out. If you need GetString, ExecuteBang, and/or section variables 
+// and you have read what they are used for from the SDK docs, uncomment the function(s)
+// and/or add a function name to use for the section variable function(s). 
+// Otherwise leave them commented out (or get rid of them)!
 
 struct Measure
 {
@@ -39,6 +40,12 @@ PLUGIN_EXPORT double Update(void* data)
 //PLUGIN_EXPORT void ExecuteBang(void* data, LPCWSTR args)
 //{
 //	Measure* measure = (Measure*)data;
+//}
+
+//PLUGIN_EXPORT LPCWSTR (void* data, const int argc, const WCHAR* argv[] argv)
+//{
+//	Measure* measure = (Measure*)data;
+//	return nullptr;
 //}
 
 PLUGIN_EXPORT void Finalize(void* data)

--- a/C++/PluginParentChild/PluginParentChild.cpp
+++ b/C++/PluginParentChild/PluginParentChild.cpp
@@ -133,7 +133,7 @@ PLUGIN_EXPORT void Initialize(void** data, void* rm)
 			}
 		}
 
-		RmLog(LOG_ERROR, L"ParentChild.dll: Invalid ParentName=");
+		RmLog(rm, LOG_ERROR, L"ParentChild.dll: Invalid ParentName=");
 	}
 }
 
@@ -163,7 +163,7 @@ PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
 	}
 	else
 	{
-		RmLog(LOG_ERROR, L"ParentChild.dll: Invalid Type=");
+		RmLog(rm, LOG_ERROR, L"ParentChild.dll: Invalid Type=");
 	}
 
 	// Read parent specific options

--- a/C++/PluginRmExecute/PluginRmExecute.cpp
+++ b/C++/PluginRmExecute/PluginRmExecute.cpp
@@ -1,0 +1,125 @@
+/*
+Copyright (C) 2017 Trevor Hamilton
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#include <Windows.h>
+#include "../../API/RainmeterAPI.h"
+#include <string>
+#include <ctime>
+
+// Overview: This is an example of how to make an option be read and execute the bang within.
+// It also showcases how you can get some of the affects of DynamicVariables=1 without as much
+// of a performance hit. As well it also shows why you should be careful of skins turning on DV=1
+
+// Sample skin:
+/*
+[Rainmeter]
+Update=1000
+DynamicWindowSize=1
+BackgroundMode=2
+SolidColor=255,255,255
+
+[Variables]
+Count=0
+Timer=5
+
+;This measure will change TextCount after #Timer# seconds
+[mTimer]
+Measure=Plugin
+Plugin=RmExecute.dll
+Timer=#Timer#
+OnTimer=[!SetOption TextCount Text "This text has changed!"]
+
+[TextCount]
+Meter=String
+X=0
+Y=0R
+FontSize=20
+Text=This text has not changed yet.
+
+[mTimerC]
+Measure=Plugin
+Plugin=RmExecute.dll
+Timer=#Timer#
+;Notice how we can even do more complex bangs.
+;If you uncomment the code in update the variable reference will even autoupdate without DynamicVariables=1
+;Or you could just uncomment DynamicVariables=1
+OnTimer=[!SetVariable Count "(#Count#+1)"][!SetOption TextCountC Text "This text has been updated #Count# times"]
+;DynamicVariables=1
+
+[TextCountC]
+Meter=String
+X=0
+Y=0R
+FontSize=20
+Text=This text has been updated #Count# times
+*/
+
+struct Measure
+{
+	Measure() {}
+	std::wstring myCommand = L"";
+	int updateRate;
+	time_t timer;
+
+	void* skin;
+	void* rm;
+};
+
+PLUGIN_EXPORT void Initialize(void** data, void* rm)
+{
+	Measure* measure = new Measure;
+	*data = measure;
+	measure->skin = RmGetSkin(rm);
+	measure->rm = rm;
+
+	//We do this in Initialize so that if a skin were to turn on DynamicVariables it will not break the plugin
+	measure->timer = std::time(0);
+}
+
+PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+{
+	Measure* measure = (Measure*)data;
+	measure->updateRate = RmReadInt(rm, L"Timer", 1);
+	//We dont have to replace measures here as they will be replaced during RmExecute.
+	measure->myCommand = RmReadString(rm, L"OnTimer", L"", false);
+}
+
+PLUGIN_EXPORT double Update(void* data)
+{
+	Measure* measure = (Measure*)data;
+
+	int timePassed = std::time(0) - measure->timer;
+
+	if (timePassed >= measure->updateRate)
+	{
+		//We could also do something like this to get DynamicVariables without the need to turn them on. Uncomment this to see the second example work
+		//measure->myCommand = RmReadString(measure->rm, L"OnTimer", L"", false);
+
+		RmExecute(measure->skin, measure->myCommand.c_str());
+		measure->timer = std::time(0);
+	}
+
+	//Even if you don't plan for users to use it returning a value can be useful for helping with skin debugging
+	return measure->updateRate - timePassed;
+}
+
+PLUGIN_EXPORT void Finalize(void* data)
+{
+	Measure* measure = (Measure*)data;
+	delete measure;
+}

--- a/C++/PluginRmExecute/PluginRmExecute.cpp
+++ b/C++/PluginRmExecute/PluginRmExecute.cpp
@@ -94,8 +94,9 @@ PLUGIN_EXPORT void Initialize(void** data, void* rm)
 PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
 {
 	Measure* measure = (Measure*)data;
-	measure->updateRate = RmReadInt(rm, L"Timer", 1);
-	//We dont have to replace measures here as they will be replaced during RmExecute.
+	measure->updateRate = RmReadInt(rm, L"Timer", 1); 
+	//We dont have to replace measures here as they will be replaced during RmExecute so we can pass false. 
+    //Note though that doing that measures will always then have their current info in update but variables will not. See the commented out code below to have both always act like DynamicVariables=1
 	measure->myCommand = RmReadString(rm, L"OnTimer", L"", false);
 }
 

--- a/C++/PluginRmExecute/PluginRmExecute.filters
+++ b/C++/PluginRmExecute/PluginRmExecute.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ResourceCompile Include="PluginRmExecute.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PluginRmExecute.cpp" />
+  </ItemGroup>
+</Project>

--- a/C++/PluginRmExecute/PluginRmExecute.rc
+++ b/C++/PluginRmExecute/PluginRmExecute.rc
@@ -1,0 +1,43 @@
+#define APSTUDIO_READONLY_SYMBOLS
+#include <windows.h>
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION 3,0,2,2161
+ FILEFLAGSMASK 0x17L
+#ifdef _DEBUG
+ FILEFLAGS VS_FF_DEBUG
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS	VOS_NT_WINDOWS32
+ FILETYPE VFT_DLL
+ FILESUBTYPE VFT_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "FileVersion", "1.0.0.0"
+            VALUE "LegalCopyright", "© 2014 - YOUR NAME"
+
+            // Don't change the entries below!
+            VALUE "ProductName", "Rainmeter"
+#ifdef _WIN64
+            VALUE "ProductVersion", "3.0.2.2161 (64-bit)"
+#else
+            VALUE "ProductVersion", "3.0.2.2161 (32-bit)"
+#endif //_WIN64
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END

--- a/C++/PluginRmExecute/PluginRmExecute.vcxproj
+++ b/C++/PluginRmExecute/PluginRmExecute.vcxproj
@@ -129,8 +129,8 @@
       <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>taskkill /f /fi "imagename eq Rainmeter.exe"
-xcopy  "$(TargetDir)$(TargetFileName)" "%appdata%\Rainmeter\Plugins" /Y</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/C++/PluginRmExecute/PluginRmExecute.vcxproj
+++ b/C++/PluginRmExecute/PluginRmExecute.vcxproj
@@ -19,15 +19,15 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="PluginDataHandling.rc" />
+    <ResourceCompile Include="PluginRmExecute.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="PluginDataHandling.cpp" />
+    <ClCompile Include="PluginRmExecute.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}</ProjectGuid>
+    <ProjectGuid>{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>PluginDataHandling</RootNamespace>
+    <RootNamespace>PluginRmExecute</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -74,25 +74,25 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>DataHandling</TargetName>
+    <TargetName>RmExecute</TargetName>
     <OutDir>x32\$(Configuration)\</OutDir>
     <IntDir>x32\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>DataHandling</TargetName>
+    <TargetName>RmExecute</TargetName>
     <OutDir>x64\$(Configuration)\</OutDir>
     <IntDir>x64\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>DataHandling</TargetName>
+    <TargetName>RmExecute</TargetName>
     <OutDir>x32\$(Configuration)\</OutDir>
     <IntDir>x32\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>DataHandling</TargetName>
+    <TargetName>RmExecute</TargetName>
     <OutDir>x64\$(Configuration)\</OutDir>
     <IntDir>x64\$(Configuration)\</IntDir>
   </PropertyGroup>
@@ -102,7 +102,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINRmExecute_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -117,7 +117,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINRmExecute_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -129,8 +129,8 @@
       <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>
-      </Command>
+      <Command>taskkill /f /fi "imagename eq Rainmeter.exe"
+xcopy  "$(TargetDir)$(TargetFileName)" "%appdata%\Rainmeter\Plugins" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -141,7 +141,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINRmExecute_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -161,7 +161,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINDataHandling_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINRmExecute_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/C++/PluginSectionVariables/PluginSectionVariables.cpp
+++ b/C++/PluginSectionVariables/PluginSectionVariables.cpp
@@ -1,0 +1,137 @@
+/*
+Copyright (C) 2017 Trevor Hamilton
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#include <Windows.h>
+#include "../../API/RainmeterAPI.h"
+#include <string>
+#include <algorithm>
+
+// Overview: This example demonstrates using plugin section variables, aka calling a plugin inline.
+// In this example we build a ToUpper and a ToLower section variable that can either get the measure text 
+// or transform the string passed to uppercase/lowercase
+
+// Sample skin:
+/*
+[Rainmeter]
+Update=1000
+DynamicWindowSize=1
+BackgroundMode=2
+SolidColor=255,255,255
+
+[Variables]
+;You can't get a Meter's text so use a variable
+TextString=Click me to make me uppercase!
+
+[mString]
+Measure=Plugin
+Plugin=SectionVariables.dll
+Input=I come from the measure reference!
+
+[TextLower]
+Meter=String
+X=0
+Y=0
+FontSize=20
+;Notice how we need DynamicVariable=1 since section variables can not be called on initialize
+Text=[&mString:ToLower()]
+DynamicVariables=1
+
+[TextUpper]
+Meter=String
+X=0
+Y=0R
+FontSize=20
+Text=#TextString#
+;Notice how we don't need DynamicVariables=1 if we set the text manually
+LeftMouseUpAction=[!SetOption TextUpper Text "[&mString:ToUpper(#TextString#)]"]
+*/
+
+struct Measure
+{
+	Measure() {}
+	std::wstring myString; //The string returned in GetString is stored here
+};
+
+PLUGIN_EXPORT void Initialize(void** data, void* rm)
+{
+	Measure* measure = new Measure;
+	*data = measure;
+}
+
+PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
+{
+	Measure* measure = (Measure*)data;
+
+	//Read measure for an Input string
+	measure->myString = RmReadString(rm, L"Input", L"");
+}
+
+PLUGIN_EXPORT double Update(void* data)
+{
+	Measure* measure = (Measure*)data;
+	return 0.0;
+}
+
+PLUGIN_EXPORT LPCWSTR GetString(void* data)
+{
+	Measure* measure = (Measure*)data;
+	return measure->myString.c_str();
+}
+
+std::wstring stringBuffer; //String buffer is used to make sure that the string we return does not get deallocated before Rainmeter can use it
+
+PLUGIN_EXPORT LPCWSTR ToUpper(void* data, const int argc, const WCHAR* argv[])
+{
+	Measure* measure = (Measure*)data;
+
+	//If we are given one or more arguments transform the first one
+	if (argc > 0)
+	{
+		stringBuffer = argv[0];
+		std::transform(stringBuffer.begin(), stringBuffer.end(), stringBuffer.begin(), ::toupper);
+		return stringBuffer.c_str();
+	}
+
+	//If we are given no arguments transform the string we recived with the input option
+	stringBuffer = measure->myString;
+	std::transform(stringBuffer.begin(), stringBuffer.end(), stringBuffer.begin(), ::toupper);
+	return stringBuffer.c_str();
+}
+PLUGIN_EXPORT LPCWSTR ToLower(void* data, const int argc, const WCHAR* argv[])
+{
+	Measure* measure = (Measure*)data;
+
+	//If we are given one or more arguments transform the first one
+	if (argc > 0)
+	{
+		stringBuffer = argv[0];
+		std::transform(stringBuffer.begin(), stringBuffer.end(), stringBuffer.begin(), ::tolower);
+		return stringBuffer.c_str();
+	}
+
+	//If we are given no arguments transform the string we recived with the input option
+	stringBuffer = measure->myString;
+	std::transform(stringBuffer.begin(), stringBuffer.end(), stringBuffer.begin(), ::tolower);
+	return stringBuffer.c_str();
+}
+
+PLUGIN_EXPORT void Finalize(void* data)
+{
+	Measure* measure = (Measure*)data;
+	delete measure;
+}

--- a/C++/PluginSectionVariables/PluginSectionVariables.filters
+++ b/C++/PluginSectionVariables/PluginSectionVariables.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ResourceCompile Include="PluginSectionVariables.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PluginSectionVariables.cpp" />
+  </ItemGroup>
+</Project>

--- a/C++/PluginSectionVariables/PluginSectionVariables.rc
+++ b/C++/PluginSectionVariables/PluginSectionVariables.rc
@@ -1,0 +1,43 @@
+#define APSTUDIO_READONLY_SYMBOLS
+#include <windows.h>
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,0,0,0
+ PRODUCTVERSION 3,0,2,2161
+ FILEFLAGSMASK 0x17L
+#ifdef _DEBUG
+ FILEFLAGS VS_FF_DEBUG
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS	VOS_NT_WINDOWS32
+ FILETYPE VFT_DLL
+ FILESUBTYPE VFT_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "FileVersion", "1.0.0.0"
+            VALUE "LegalCopyright", "© 2014 - YOUR NAME"
+
+            // Don't change the entries below!
+            VALUE "ProductName", "Rainmeter"
+#ifdef _WIN64
+            VALUE "ProductVersion", "3.0.2.2161 (64-bit)"
+#else
+            VALUE "ProductVersion", "3.0.2.2161 (32-bit)"
+#endif //_WIN64
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END

--- a/C++/PluginSectionVariables/PluginSectionVariables.vcxproj
+++ b/C++/PluginSectionVariables/PluginSectionVariables.vcxproj
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="PluginSectionVariables.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PluginSectionVariables.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{da0c1f65-a686-4741-af21-32097240fd2e}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>PluginSectionVariables</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>SectionVariables</TargetName>
+    <OutDir>x32\$(Configuration)\</OutDir>
+    <IntDir>x32\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>SectionVariables</TargetName>
+    <OutDir>x64\$(Configuration)\</OutDir>
+    <IntDir>x64\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>SectionVariables</TargetName>
+    <OutDir>x32\$(Configuration)\</OutDir>
+    <IntDir>x32\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>SectionVariables</TargetName>
+    <OutDir>x64\$(Configuration)\</OutDir>
+    <IntDir>x64\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINSectionVariables_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\API\x32\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PLUGINSectionVariables_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\API\x64\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINSectionVariables_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <MergeSections>.rdata=.text</MergeSections>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\API\x32\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PLUGINSectionVariables_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <MergeSections>.rdata=.text</MergeSections>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\API\x64\Rainmeter.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/C++/PluginSystemVersion/PluginSystemVersion.cpp
+++ b/C++/PluginSystemVersion/PluginSystemVersion.cpp
@@ -121,7 +121,7 @@ PLUGIN_EXPORT void Reload(void* data, void* rm, double* maxValue)
 	}
 	else
 	{
-		RmLog(LOG_ERROR, L"SystemVersion.dll: Invalid Type=");
+		RmLog(rm, LOG_ERROR, L"SystemVersion.dll: Invalid Type=");
 	}
 }
 

--- a/C++/SDK-CPP.sln
+++ b/C++/SDK-CPP.sln
@@ -1,11 +1,19 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2017
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.10
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginEmpty", "PluginEmpty\PluginEmpty.vcxproj", "{64FDEE97-6B7E-40E5-A489-ECA322825BC8}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginSystemVersion", "PluginSystemVersion\PluginSystemVersion.vcxproj", "{7FB00A1C-F0C0-49FD-A15C-392F69FDF645}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginParentChild", "PluginParentChild\PluginParentChild.vcxproj", "{CDA75744-28E9-41CB-849E-BF9DD936C794}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginSectionVariables", "PluginSectionVariables\PluginSectionVariables.vcxproj", "{DA0C1F65-A686-4741-AF21-32097240FD2E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginDataHandling", "PluginDataHandling\PluginDataHandling.vcxproj", "{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginRmExecute", "PluginRmExecute\PluginRmExecute.vcxproj", "{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,8 +47,35 @@ Global
 		{CDA75744-28E9-41CB-849E-BF9DD936C794}.Release|Win32.Build.0 = Release|Win32
 		{CDA75744-28E9-41CB-849E-BF9DD936C794}.Release|x64.ActiveCfg = Release|x64
 		{CDA75744-28E9-41CB-849E-BF9DD936C794}.Release|x64.Build.0 = Release|x64
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Debug|Win32.Build.0 = Debug|Win32
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Debug|x64.ActiveCfg = Debug|x64
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Debug|x64.Build.0 = Debug|x64
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Release|Win32.ActiveCfg = Release|Win32
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Release|Win32.Build.0 = Release|Win32
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Release|x64.ActiveCfg = Release|x64
+		{DA0C1F65-A686-4741-AF21-32097240FD2E}.Release|x64.Build.0 = Release|x64
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Debug|Win32.ActiveCfg = Debug|Win32
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Debug|Win32.Build.0 = Debug|Win32
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Debug|x64.ActiveCfg = Debug|x64
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Debug|x64.Build.0 = Debug|x64
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Release|Win32.ActiveCfg = Release|Win32
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Release|Win32.Build.0 = Release|Win32
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Release|x64.ActiveCfg = Release|x64
+		{8CAA57CE-289D-4365-AC1F-0C6E3E5B76B8}.Release|x64.Build.0 = Release|x64
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Debug|Win32.ActiveCfg = Debug|Win32
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Debug|Win32.Build.0 = Debug|Win32
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Debug|x64.ActiveCfg = Debug|x64
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Debug|x64.Build.0 = Debug|x64
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Release|Win32.ActiveCfg = Release|Win32
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Release|Win32.Build.0 = Release|Win32
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Release|x64.ActiveCfg = Release|x64
+		{31ACF3A1-2547-4CD1-9200-EF3E665B07BC}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0BB5493F-241B-4D0D-B3C2-04F57BA7BA16}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
As I discussed in IRC here are my recommended changes to the SDK.
I also updated all examples to use logging with a source.
Updated the C# blank example to be more simple out of the box (I left the existing two examples to be the old two class way so people can look at those). Both blank examples now also include a unnamed SectionVariable function.
Added 3 new examples:
SectionVariables tries to showcase the power and limitations of section variables.
DataHandling goes over how to store data in the argument passed with all functions. It also goes over storing data in the Rainmeter.Data file (Important for C# users).
RmExecute goes over how to use execute and also showcases why you have to be careful of DynamicVariables.