### PR TITLE
Update PluginParentChild.cpp

### DIFF
--- a/C++/PluginParentChild/PluginParentChild.cpp
+++ b/C++/PluginParentChild/PluginParentChild.cpp
@@ -89,7 +89,8 @@ struct ChildMeasure
 	ParentMeasure* parent;
 
 	ChildMeasure() : 
-		type(MEASURE_A) {}
+		type(MEASURE_A),
+		parent(nullptr) {}
 };
 
 std::vector<ParentMeasure*> g_ParentMeasures;


### PR DESCRIPTION
Fix "ParentMeasure* parent" initialization, so "if (!parent)" will work now.